### PR TITLE
Pass correct arg newProjectNames to assignToProjects

### DIFF
--- a/__tests__/get-new-projects.test.js
+++ b/__tests__/get-new-projects.test.js
@@ -1,20 +1,20 @@
-const { getNewProjects } = require('../new-projects');
+const { getNewProjectNames } = require('../new-projects');
 
 const fooproj = { node: { project: { name: 'foo' } } };
 const barproj = { node: { project: { name: 'bar' } } };
 
 test('no new projects when current and target are both empty', async () => {
-  expect(getNewProjects([], [])).toStrictEqual([]);
+  expect(getNewProjectNames([], [])).toStrictEqual([]);
 });
 
 test('no new projects when target is empty', async () => {
-  expect(getNewProjects([fooproj], [])).toStrictEqual([]);
+  expect(getNewProjectNames([fooproj], [])).toStrictEqual([]);
 });
 
 test('new projects when current is empty', async () => {
-  expect(getNewProjects([], ['foo'])).toStrictEqual(['foo']);
+  expect(getNewProjectNames([], ['foo'])).toStrictEqual(['foo']);
 });
 
 test('new projects are what is in target but not current', async () => {
-  expect(getNewProjects([fooproj, barproj], ['bar', 'baz'])).toStrictEqual(['baz']);
+  expect(getNewProjectNames([fooproj, barproj], ['bar', 'baz'])).toStrictEqual(['baz']);
 });

--- a/dist/index.js
+++ b/dist/index.js
@@ -81,7 +81,7 @@ exports.GithubHelper = class {
 /***/ 961:
 /***/ ((__unused_webpack_module, exports) => {
 
-exports.getNewProjects = (currentProjects, targetProjectNames) => {
+exports.getNewProjectNames = (currentProjects, targetProjectNames) => {
   const currentProjectNames = currentProjects.map((project) => project.node.project.name);
 
   return targetProjectNames.filter((p) => !currentProjectNames.includes(p));
@@ -8533,7 +8533,7 @@ var __webpack_exports__ = {};
 (() => {
 const core = __nccwpck_require__(2186);
 const github = __nccwpck_require__(5438);
-const { getNewProjects } = __nccwpck_require__(961);
+const { getNewProjectNames } = __nccwpck_require__(961);
 const { GithubHelper } = __nccwpck_require__(9812);
 
 async function run() {
@@ -8543,14 +8543,14 @@ async function run() {
     const token = core.getInput('github-token', { required: true });
     const octokit = github.getOctokit(token);
 
-    const newProjects = getNewProjects(currentProjects, targetProjects);
+    const newProjectNames = getNewProjectNames(currentProjects, targetProjects);
     const githubHelper = new GithubHelper({
       client: octokit,
       context: github.context,
     });
     await githubHelper.assignToProjects({
       columnName: core.getInput('column-name', { required: true }),
-      newProjects,
+      newProjectNames,
     });
   } catch (error) {
     core.setFailed(error.message);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const core = require('@actions/core');
 const github = require('@actions/github');
-const { getNewProjects } = require('./new-projects');
+const { getNewProjectNames } = require('./new-projects');
 const { GithubHelper } = require('./github-helper');
 
 async function run() {
@@ -10,14 +10,14 @@ async function run() {
     const token = core.getInput('github-token', { required: true });
     const octokit = github.getOctokit(token);
 
-    const newProjects = getNewProjects(currentProjects, targetProjects);
+    const newProjectNames = getNewProjectNames(currentProjects, targetProjects);
     const githubHelper = new GithubHelper({
       client: octokit,
       context: github.context,
     });
     await githubHelper.assignToProjects({
       columnName: core.getInput('column-name', { required: true }),
-      newProjects,
+      newProjectNames,
     });
   } catch (error) {
     core.setFailed(error.message);

--- a/new-projects.js
+++ b/new-projects.js
@@ -1,4 +1,4 @@
-exports.getNewProjects = (currentProjects, targetProjectNames) => {
+exports.getNewProjectNames = (currentProjects, targetProjectNames) => {
   const currentProjectNames = currentProjects.map((project) => project.node.project.name);
 
   return targetProjectNames.filter((p) => !currentProjectNames.includes(p));


### PR DESCRIPTION
- pass the correct arg to fix `Cannot read property 'includes' of undefined`
- change method name to `getNewProjectNames` because that's what it returns